### PR TITLE
Add support for SG-1000

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to coding agents collaborating on this repository.
 
 ## Mission
 
-Sandopolis is a portable and accurate multi-system Sega emulator for Genesis, Master System, and Game Gear, written in Zig (and C).
+Sandopolis is a portable and accurate multi-system Sega emulator for Genesis, Master System, Game Gear, and SG-1000, written in Zig (and C).
 Priorities, in order:
 
 1. Correct emulation behavior and compatibility.

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@
 [![Play Online](https://img.shields.io/badge/play%20online-browser-007ec6?style=flat&labelColor=282c34&logo=webassembly)](https://pixel-clover.github.io/sandopolis/)
 [![Docker](https://img.shields.io/badge/docker-ghcr.io-007ec6?style=flat&labelColor=282c34&logo=docker)](https://github.com/orgs/pixel-clover/packages/container/package/sandopolis-web)
 <br>
-[![Systems](https://img.shields.io/badge/systems-Genesis%20%7C%20Master%20System%20%7C%20Game%20Gear-44cc11?style=flat&labelColor=282c34)](https://github.com/pixel-clover/sandopolis)
+[![Systems](https://img.shields.io/badge/systems-Genesis%20%7C%20Master%20System%20%7C%20Game%20Gear%20%7C%20SG--1000-44cc11?style=flat&labelColor=282c34)](https://github.com/pixel-clover/sandopolis)
 [![Platforms](https://img.shields.io/badge/platforms-Desktop%20%7C%20Web%20%7C%20Libretro-44cc11?style=flat&labelColor=282c34)](https://github.com/pixel-clover/sandopolis)
 
-A portable multi-system Sega emulator for Genesis, Master System, and Game Gear
+A portable multi-system Sega emulator for Genesis, Master System, Game Gear, and SG-1000
 
 </div>
 
@@ -44,7 +44,7 @@ Footage of Sandopolis running a few games:
 
 ### Key Features
 
-- Accurate Sega Genesis/Mega Drive, Master System, and Game Gear emulation
+- Accurate Sega Genesis/Mega Drive, Master System, Game Gear, and SG-1000 emulation
 - Very portable; can be built and run on any platform that Zig supports
 - Very configurable, including gameplay input, frontend hotkeys, and rendering settings
 - Has a permissive license that allows commercial use
@@ -123,13 +123,13 @@ Run `sandopolis --help` to see the list of available command-line options.
 Example output:
 
 ```
-A portable multi-system Sega emulator for Genesis, Master System, and Game Gear
+A portable multi-system Sega emulator for Genesis, Master System, Game Gear, and SG-1000
 
 Usage:
   sandopolis [flags] [rom_file]
 
 Arguments:
-  rom_file  Path to a ROM file (.bin, .md, .smd, .gen, .sms, .gg) or a .zip archive containing one (optional)
+  rom_file  Path to a ROM file (.bin, .md, .smd, .gen, .sms, .gg, .sg) or a .zip archive containing one (optional)
 
 Flags:
   -h, --help            Shows help information for this command [Bool] (default: false)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -117,9 +117,25 @@ This document outlines the features implemented in Sandopolis emulator and the f
 - [x] Desktop integer scaling and pixel-perfect aspect ratio correction (nearest-neighbor texture filtering)
 - [x] Tooltip help text on web controls and context-sensitive hint line in desktop settings
 - [ ] Browser CRT shader option
+- [ ] NTSC composite video filter (Blargg's or equivalent)
+- [ ] Game Gear LCD ghosting emulation
+- [ ] Anti-dither shader
 - [ ] SG-1000 subsystem support
 - [ ] Sega CD subsystem support
 - [ ] 32X subsystem support
+- [ ] Sega Pico subsystem support
+- [ ] Cheat code support (Game Genie and Action Replay)
+- [ ] Lock-on cartridge emulation (like Sonic & Knuckles)
+- [ ] Rewind functionality (per-frame state history)
+- [ ] CPU overclocking options
+
+### Input Peripherals
+
+- [ ] Light guns (Sega Light Phaser, Menacer, and Konami Justifiers)
+- [ ] Sega Paddle Control
+- [ ] Sega Sports Pad
+- [ ] XE-1AP analog controller
+- [ ] Sega Activator
 
 ### Sega Master System Support
 
@@ -148,5 +164,7 @@ This document outlines the features implemented in Sandopolis emulator and the f
 - [x] SMS quick save states (in-memory capture and restore of Z80, VDP, bus, and audio state)
 - [x] SMS persistent save states (file-based serialization with source path, Z80, VDP, bus, and audio state)
 - [ ] Korean mapper variants (MSX, Nemesis, and Janggun)
+- [ ] Codemasters mapper
 - [ ] BIOS/boot ROM support
 - [ ] FM sound unit (YM2413) for Japanese SMS and Mark III
+- [ ] Per-game compatibility database for mapper and setting detection

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -120,7 +120,7 @@ This document outlines the features implemented in Sandopolis emulator and the f
 - [ ] NTSC composite video filter (Blargg's or equivalent)
 - [ ] Game Gear LCD ghosting emulation
 - [ ] Anti-dither shader
-- [ ] SG-1000 subsystem support
+- [x] SG-1000 subsystem support (TMS9918A VDP Modes 0-3, 1KB RAM bus, TMS sprite rendering)
 - [ ] Sega CD subsystem support
 - [ ] 32X subsystem support
 - [ ] Sega Pico subsystem support

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -77,7 +77,7 @@ fn exec(ctx: chilli.CommandContext) !void {
 pub fn createCommand(allocator: std.mem.Allocator) !*chilli.Command {
     var cmd = try chilli.Command.init(allocator, .{
         .name = "sandopolis",
-        .description = "A portable multi-system Sega emulator for Genesis, Master System, and Game Gear",
+        .description = "A portable multi-system Sega emulator for Genesis, Master System, Game Gear, and SG-1000",
         .exec = exec,
     });
 
@@ -125,7 +125,7 @@ pub fn createCommand(allocator: std.mem.Allocator) !*chilli.Command {
     });
     try cmd.addPositional(.{
         .name = "rom_file",
-        .description = "Path to a ROM file (.bin, .md, .smd, .gen, .sms, .gg) or a .zip archive containing one",
+        .description = "Path to a ROM file (.bin, .md, .smd, .gen, .sms, .gg, .sg) or a .zip archive containing one",
         .default_value = .{ .String = "" },
     });
 

--- a/src/frontend/config.zig
+++ b/src/frontend/config.zig
@@ -491,6 +491,50 @@ test "whole_pixels does not floor below 1x" {
     try t.expectApproxEqAbs(@as(f32, 140.0), r.h, 0.01);
 }
 
+test "four_three aspect ratio is correct for each console resolution" {
+    const viewport = zsdl3.Rect{ .x = 0, .y = 0, .w = 1280, .h = 720 };
+
+    // Genesis H40 (320x224): 4:3
+    const gen = computeVideoDestinationRect(viewport, 320, 224, .four_three, .fit);
+    try t.expectApproxEqAbs(@as(f32, 4.0 / 3.0), gen.w / gen.h, 0.01);
+
+    // Genesis H32 (256x224): 4:3
+    const gen32 = computeVideoDestinationRect(viewport, 256, 224, .four_three, .fit);
+    try t.expectApproxEqAbs(@as(f32, 4.0 / 3.0), gen32.w / gen32.h, 0.01);
+
+    // SMS (256x192): 4:3
+    const sms = computeVideoDestinationRect(viewport, 256, 192, .four_three, .fit);
+    try t.expectApproxEqAbs(@as(f32, 4.0 / 3.0), sms.w / sms.h, 0.01);
+
+    // SG-1000 (256x192): 4:3
+    const sg = computeVideoDestinationRect(viewport, 256, 192, .four_three, .fit);
+    try t.expectApproxEqAbs(@as(f32, 4.0 / 3.0), sg.w / sg.h, 0.01);
+
+    // Game Gear (160x144): 4:3 (stretched, but valid user choice)
+    const gg = computeVideoDestinationRect(viewport, 160, 144, .four_three, .fit);
+    try t.expectApproxEqAbs(@as(f32, 4.0 / 3.0), gg.w / gg.h, 0.01);
+}
+
+test "square_pixels preserves native pixel aspect for each console" {
+    const viewport = zsdl3.Rect{ .x = 0, .y = 0, .w = 1280, .h = 720 };
+
+    // Genesis H40 (320x224): 320:224 ≈ 1.4286
+    const gen = computeVideoDestinationRect(viewport, 320, 224, .square_pixels, .fit);
+    try t.expectApproxEqAbs(@as(f32, 320.0 / 224.0), gen.w / gen.h, 0.01);
+
+    // SMS (256x192): 256:192 = 4:3
+    const sms = computeVideoDestinationRect(viewport, 256, 192, .square_pixels, .fit);
+    try t.expectApproxEqAbs(@as(f32, 256.0 / 192.0), sms.w / sms.h, 0.01);
+
+    // Game Gear (160x144): 160:144 = 10:9
+    const gg = computeVideoDestinationRect(viewport, 160, 144, .square_pixels, .fit);
+    try t.expectApproxEqAbs(@as(f32, 160.0 / 144.0), gg.w / gg.h, 0.01);
+
+    // SG-1000 (256x192): same as SMS
+    const sg = computeVideoDestinationRect(viewport, 256, 192, .square_pixels, .fit);
+    try t.expectApproxEqAbs(@as(f32, 4.0 / 3.0), sg.w / sg.h, 0.01);
+}
+
 test "PathCopy set truncates long paths" {
     var pc = PathCopy{};
     pc.set("short.md");

--- a/src/main.zig
+++ b/src/main.zig
@@ -699,7 +699,7 @@ const SdlDialogFileFilter = extern struct {
 };
 
 const rom_dialog_filters = [_]SdlDialogFileFilter{
-    .{ .name = "ROM files", .pattern = "bin;md;smd;gen;sms;gg;zip" },
+    .{ .name = "ROM files", .pattern = "bin;md;smd;gen;sms;gg;sg;zip" },
     .{ .name = "All files", .pattern = "*" },
 };
 
@@ -3877,7 +3877,7 @@ pub fn main() !void {
         const sample_core_counters = shouldSampleCoreCounters(frontend_ui.overlay == .performance_hud, frame_counter, core_profile_frames_remaining);
         if (!emulation_paused) {
             const sys = machine.systemType();
-            target_frame_ns = if (sys == .sms or sys == .gg)
+            target_frame_ns = if (sys == .sms or sys == .gg or sys == .sg1000)
                 smsFrameDurationNs(machine.palMode())
             else
                 frameDurationNs(machine.palMode(), machine.frameMasterCycles());

--- a/src/rom_loader.zig
+++ b/src/rom_loader.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const testing = std.testing;
 
 /// ROM file extensions recognized inside ZIP archives.
-const rom_extensions = [_][]const u8{ ".bin", ".md", ".smd", ".gen", ".sms", ".gg" };
+const rom_extensions = [_][]const u8{ ".bin", ".md", ".smd", ".gen", ".sms", ".gg", ".sg" };
 
 /// Read a ROM file from disk. If the file is a ZIP archive (detected by "PK"
 /// magic bytes), the first entry with a recognized ROM extension is extracted

--- a/src/sms/bus.zig
+++ b/src/sms/bus.zig
@@ -18,6 +18,7 @@ pub const SmsBus = struct {
     rom_owned: bool = false,
     source_path: ?[]const u8 = null,
     source_path_owned: bool = false,
+    is_sg1000: bool = false,
     ram: [8 * 1024]u8 = [_]u8{0} ** (8 * 1024),
     vdp: SmsVdp = SmsVdp.init(),
     input: SmsInput = SmsInput{},
@@ -107,6 +108,13 @@ pub const SmsBus = struct {
     }
 
     pub fn read(self: *const SmsBus, addr: u16) u8 {
+        // SG-1000: flat ROM up to 0xBFFF, 1KB RAM at 0xC000 mirrored
+        if (self.is_sg1000) {
+            if (addr < 0xC000) {
+                return if (addr < self.rom.len) self.rom[addr] else 0xFF;
+            }
+            return self.ram[addr & 0x03FF]; // 1KB mirrored
+        }
         if (addr < 0x0400) {
             // First 1KB: always from ROM start
             return if (addr < self.rom.len) self.rom[addr] else 0xFF;
@@ -135,6 +143,13 @@ pub const SmsBus = struct {
     }
 
     pub fn write(self: *SmsBus, addr: u16, value: u8) void {
+        // SG-1000: no mapper, 1KB RAM at 0xC000 mirrored
+        if (self.is_sg1000) {
+            if (addr >= 0xC000) {
+                self.ram[addr & 0x03FF] = value;
+            }
+            return;
+        }
         if (addr < 0x8000) {
             // ROM area: writes are ignored (no mapper in low pages)
             return;

--- a/src/sms/machine.zig
+++ b/src/sms/machine.zig
@@ -13,6 +13,7 @@ pub const SmsMachine = struct {
     audio: SmsAudio = SmsAudio.init(),
     pal_mode: bool = false,
     is_game_gear: bool = false,
+    is_sg1000: bool = false,
     z80_cycle_count: u32 = 0,
 
     // Audio buffer for frame output
@@ -40,9 +41,11 @@ pub const SmsMachine = struct {
     /// the SmsMachine reaches its final memory location (e.g., after being
     /// assigned into a heap-allocated WasmEmulator).
     pub fn bindPointers(self: *SmsMachine) void {
-        // Propagate GG flag to VDP and I/O
+        // Propagate variant flags to VDP and I/O
         self.bus.vdp.is_game_gear = self.is_game_gear;
         self.bus.io.is_game_gear = self.is_game_gear;
+        self.bus.vdp.is_sg1000 = self.is_sg1000;
+        self.bus.is_sg1000 = self.is_sg1000;
 
         // Fix SmsBus internal pointers (io.vdp, io.input)
         self.bus.rebindPointers();
@@ -147,8 +150,8 @@ pub const SmsMachine = struct {
             self.z80.clearIrq();
         }
 
-        // Handle pause button NMI (SMS only; GG START is read via port 0x00)
-        if (!self.is_game_gear and self.bus.input.pause_pressed) {
+        // Handle pause button NMI (SMS only; GG and SG-1000 do not use NMI pause)
+        if (!self.is_game_gear and !self.is_sg1000 and self.bus.input.pause_pressed) {
             self.z80.assertNmi();
             self.bus.input.pause_pressed = false;
         }

--- a/src/sms/vdp.zig
+++ b/src/sms/vdp.zig
@@ -26,6 +26,7 @@ pub const SmsVdp = struct {
     scanline: u16 = 0,
     pal_mode: bool = false,
     is_game_gear: bool = false,
+    is_sg1000: bool = false,
     gg_cram_latch: u8 = 0, // GG CRAM even-byte latch for two-byte writes
 
     pub const framebuffer_width: usize = 256;
@@ -37,6 +38,53 @@ pub const SmsVdp = struct {
     const status_vint: u8 = 0x80;
     const status_sprite_overflow: u8 = 0x40;
     const status_sprite_collision: u8 = 0x20;
+
+    // TMS9918A / SMS display mode classification
+    pub const GraphicsMode = enum {
+        mode4, // SMS Mode 4 (standard SMS/GG)
+        mode0_text, // TMS9918 Mode 0: 40x24 text, 6x8 chars, no sprites
+        mode1_graphics1, // TMS9918 Mode 1: 32x24 tiles, 1 color per 8 tiles
+        mode2_graphics2, // TMS9918 Mode 2: 32x24 tiles, per-row colors, 3 pattern groups
+        mode3_multicolor, // TMS9918 Mode 3: 64x48 colored blocks
+    };
+
+    /// Determine the active graphics mode from VDP register bits.
+    /// M4 (reg0 bit 2) selects SMS Mode 4. For TMS9918 modes:
+    /// M1 (reg1 bit 4), M2 (reg0 bit 1), M3 (reg1 bit 3).
+    pub fn graphicsMode(self: *const SmsVdp) GraphicsMode {
+        // SG-1000 uses a TMS9918A where register 0 bit 2 is unused (not M4).
+        // The SMS VDP repurposed that bit for Mode 4. Ignore it for SG-1000.
+        if (!self.is_sg1000 and (self.regs[0] & 0x04) != 0) return .mode4;
+        if ((self.regs[1] & 0x10) != 0) return .mode0_text;
+        if ((self.regs[0] & 0x02) != 0) return .mode2_graphics2;
+        if ((self.regs[1] & 0x08) != 0) return .mode3_multicolor;
+        return .mode1_graphics1;
+    }
+
+    // Fixed TMS9918A 16-color palette (ARGB format)
+    pub const tms_palette = [16]u32{
+        0x00000000, // 0: transparent (rendered as black)
+        0xFF000000, // 1: black
+        0xFF21C842, // 2: medium green
+        0xFF5EDC78, // 3: light green
+        0xFF5455ED, // 4: dark blue
+        0xFF7D76FC, // 5: light blue
+        0xFFD4524D, // 6: dark red
+        0xFF42EBF5, // 7: cyan
+        0xFFFC5554, // 8: medium red
+        0xFFFF7978, // 9: light red
+        0xFFD4C154, // 10: dark yellow
+        0xFFE6CE80, // 11: light yellow
+        0xFF21B03B, // 12: dark green
+        0xFFC95BBA, // 13: magenta
+        0xFFCCCCCC, // 14: gray
+        0xFFFFFFFF, // 15: white
+    };
+
+    /// Look up a TMS9918A fixed palette color by index.
+    pub fn tmsPaletteColor(index: u4) u32 {
+        return tms_palette[index];
+    }
 
     pub fn init() SmsVdp {
         return .{};
@@ -374,6 +422,14 @@ pub const SmsVdp = struct {
         var line_buf: [framebuffer_width]u32 = undefined;
         var priority_buf: [framebuffer_width]bool = [_]bool{false} ** framebuffer_width;
 
+        // TMS9918 modes use different rendering paths
+        if (self.graphicsMode() != .mode4) {
+            self.renderScanlineTms(line, &line_buf);
+            const offset = @as(usize, line) * framebuffer_width;
+            @memcpy(self.framebuffer[offset..][0..framebuffer_width], &line_buf);
+            return;
+        }
+
         // Fill with backdrop
         const bg = self.backdropColor();
         @memset(&line_buf, bg);
@@ -402,6 +458,239 @@ pub const SmsVdp = struct {
             @memcpy(self.framebuffer[offset..][0..framebuffer_width], &line_buf);
         }
     }
+
+    // -- TMS9918A rendering (SG-1000) --
+
+    fn renderScanlineTms(self: *SmsVdp, line: u16, line_buf: *[framebuffer_width]u32) void {
+        // Backdrop: register 7 lower nibble (TMS palette index)
+        const bd_color: u4 = @truncate(self.regs[7] & 0x0F);
+        const bg = if (bd_color == 0) @as(u32, 0xFF000000) else tmsPaletteColor(bd_color);
+        @memset(line_buf, bg);
+
+        switch (self.graphicsMode()) {
+            .mode2_graphics2 => self.renderBackgroundTmsMode2(line, line_buf),
+            .mode1_graphics1 => self.renderBackgroundTmsMode1(line, line_buf),
+            .mode0_text => self.renderBackgroundTmsMode0(line, line_buf),
+            .mode3_multicolor => self.renderBackgroundTmsMode3(line, line_buf),
+            .mode4 => unreachable,
+        }
+
+        // TMS sprites (all modes except Mode 0/text have sprites)
+        if (self.graphicsMode() != .mode0_text) {
+            self.renderSpritesTms(line, line_buf);
+        }
+    }
+
+    /// Mode 2 (Graphics II): 32x24 tiles, 3 pattern groups, per-row color table.
+    /// Used by ~95% of SG-1000 games.
+    fn renderBackgroundTmsMode2(self: *SmsVdp, line: u16, line_buf: *[framebuffer_width]u32) void {
+        const tile_row = line / 8;
+        const fine_y = line & 7;
+        // Name table base: register 2, bits 0-3, shifted left by 10
+        const name_base: u16 = (@as(u16, self.regs[2]) & 0x0F) << 10;
+        // Pattern generator base: register 4 bit 2 selects 0x0000 or 0x2000
+        // (masking with 0x04 then shift to get actual base; top bit acts as mask)
+        const pg_base: u16 = (@as(u16, self.regs[4]) & 0x04) << 11; // 0x0000 or 0x2000
+        const pg_mask: u16 = ((@as(u16, self.regs[4]) & 0x03) << 8) | 0xFF;
+        // Color table base: register 3 upper bits; lower bits act as mask
+        const ct_base: u16 = (@as(u16, self.regs[3]) & 0x80) << 6; // 0x0000 or 0x2000
+        const ct_mask: u16 = ((@as(u16, self.regs[3]) & 0x7F) << 3) | 0x07;
+        // Screen divided into thirds (rows 0-7, 8-15, 16-23)
+        const group_offset: u16 = (tile_row / 8) * 256;
+
+        for (0..32) |col_idx| {
+            const col: u16 = @intCast(col_idx);
+            const name_addr = name_base + tile_row * 32 + col;
+            const tile: u16 = self.vram[name_addr & 0x3FFF];
+            const pattern_index = (tile + group_offset) & pg_mask;
+            const pg_addr = pg_base + pattern_index * 8 + fine_y;
+            const ct_addr = ct_base + ((tile + group_offset) & ct_mask) * 8 + fine_y;
+            const pattern_byte = self.vram[pg_addr & 0x3FFF];
+            const color_byte = self.vram[ct_addr & 0x3FFF];
+            const fg_idx: u4 = @truncate(color_byte >> 4);
+            const bg_idx: u4 = @truncate(color_byte & 0x0F);
+            const fg = if (fg_idx == 0) @as(u32, 0xFF000000) else tmsPaletteColor(fg_idx);
+            const bg_col = if (bg_idx == 0) @as(u32, 0xFF000000) else tmsPaletteColor(bg_idx);
+
+            const x_base = col * 8;
+            inline for (0..8) |bit| {
+                const mask = @as(u8, 0x80) >> @intCast(bit);
+                const pixel = if ((pattern_byte & mask) != 0) fg else bg_col;
+                line_buf[x_base + bit] = pixel;
+            }
+        }
+    }
+
+    /// Mode 1 (Graphics I): 32x24 tiles, one pattern set, color per 8 tiles.
+    fn renderBackgroundTmsMode1(self: *SmsVdp, line: u16, line_buf: *[framebuffer_width]u32) void {
+        const tile_row = line / 8;
+        const fine_y = line & 7;
+        const name_base: u16 = (@as(u16, self.regs[2]) & 0x0F) << 10;
+        const pg_base: u16 = (@as(u16, self.regs[4]) & 0x07) << 11;
+        const ct_base: u16 = @as(u16, self.regs[3]) << 6;
+
+        for (0..32) |col_idx| {
+            const col: u16 = @intCast(col_idx);
+            const name_addr = name_base + tile_row * 32 + col;
+            const tile: u16 = self.vram[name_addr & 0x3FFF];
+            const pg_addr = pg_base + tile * 8 + fine_y;
+            // Color table: one byte per 8 tiles
+            const ct_addr = ct_base + tile / 8;
+            const pattern_byte = self.vram[pg_addr & 0x3FFF];
+            const color_byte = self.vram[ct_addr & 0x3FFF];
+            const fg_idx: u4 = @truncate(color_byte >> 4);
+            const bg_idx: u4 = @truncate(color_byte & 0x0F);
+            const fg = if (fg_idx == 0) @as(u32, 0xFF000000) else tmsPaletteColor(fg_idx);
+            const bg_col = if (bg_idx == 0) @as(u32, 0xFF000000) else tmsPaletteColor(bg_idx);
+
+            const x_base = col * 8;
+            inline for (0..8) |bit| {
+                const mask = @as(u8, 0x80) >> @intCast(bit);
+                line_buf[x_base + bit] = if ((pattern_byte & mask) != 0) fg else bg_col;
+            }
+        }
+    }
+
+    /// Mode 0 (Text): 40x24 text, 6x8 characters, no sprites.
+    fn renderBackgroundTmsMode0(self: *SmsVdp, line: u16, line_buf: *[framebuffer_width]u32) void {
+        const tile_row = line / 8;
+        const fine_y = line & 7;
+        const name_base: u16 = (@as(u16, self.regs[2]) & 0x0F) << 10;
+        const pg_base: u16 = (@as(u16, self.regs[4]) & 0x07) << 11;
+        const fg_idx: u4 = @truncate(self.regs[7] >> 4);
+        const bg_idx: u4 = @truncate(self.regs[7] & 0x0F);
+        const fg = if (fg_idx == 0) @as(u32, 0xFF000000) else tmsPaletteColor(fg_idx);
+        const bg_col = if (bg_idx == 0) @as(u32, 0xFF000000) else tmsPaletteColor(bg_idx);
+
+        // 40 columns of 6-pixel-wide chars; total = 240 pixels, centered with 8px border each side
+        for (0..40) |col_idx| {
+            const col: u16 = @intCast(col_idx);
+            const name_addr = name_base + tile_row * 40 + col;
+            const tile: u16 = self.vram[name_addr & 0x3FFF];
+            const pg_addr = pg_base + tile * 8 + fine_y;
+            const pattern_byte = self.vram[pg_addr & 0x3FFF];
+
+            const x_base = 8 + col * 6; // 8px left border
+            inline for (0..6) |bit| {
+                const mask = @as(u8, 0x80) >> @intCast(bit);
+                if (x_base + bit < framebuffer_width) {
+                    line_buf[x_base + bit] = if ((pattern_byte & mask) != 0) fg else bg_col;
+                }
+            }
+        }
+    }
+
+    /// Mode 3 (Multicolor): 64x48 colored blocks (4x4 pixel blocks).
+    fn renderBackgroundTmsMode3(self: *SmsVdp, line: u16, line_buf: *[framebuffer_width]u32) void {
+        const tile_row = line / 8;
+        const sub_row = (line / 4) & 1; // which half of the 8-pixel-tall row
+        const name_base: u16 = (@as(u16, self.regs[2]) & 0x0F) << 10;
+        const pg_base: u16 = (@as(u16, self.regs[4]) & 0x07) << 11;
+
+        for (0..32) |col_idx| {
+            const col: u16 = @intCast(col_idx);
+            const name_addr = name_base + tile_row * 32 + col;
+            const tile: u16 = self.vram[name_addr & 0x3FFF];
+            // Pattern byte encodes 2 colors (upper=left, lower=right) for this 4px sub-row
+            const pg_addr = pg_base + tile * 8 + (tile_row & 3) * 2 + sub_row;
+            const color_byte = self.vram[pg_addr & 0x3FFF];
+            const left_idx: u4 = @truncate(color_byte >> 4);
+            const right_idx: u4 = @truncate(color_byte & 0x0F);
+            const left = if (left_idx == 0) @as(u32, 0xFF000000) else tmsPaletteColor(left_idx);
+            const right = if (right_idx == 0) @as(u32, 0xFF000000) else tmsPaletteColor(right_idx);
+
+            const x_base = col * 8;
+            line_buf[x_base + 0] = left;
+            line_buf[x_base + 1] = left;
+            line_buf[x_base + 2] = left;
+            line_buf[x_base + 3] = left;
+            line_buf[x_base + 4] = right;
+            line_buf[x_base + 5] = right;
+            line_buf[x_base + 6] = right;
+            line_buf[x_base + 7] = right;
+        }
+    }
+
+    /// TMS9918 sprite rendering (shared by Modes 1, 2, 3).
+    fn renderSpritesTms(self: *SmsVdp, line: u16, line_buf: *[framebuffer_width]u32) void {
+        const sat_base: u16 = (@as(u16, self.regs[5]) & 0x7F) << 7;
+        const sg_base: u16 = (@as(u16, self.regs[6]) & 0x07) << 11;
+        const is_16x16 = (self.regs[1] & 0x02) != 0;
+        const is_magnified = (self.regs[1] & 0x01) != 0;
+        const sprite_height: u16 = if (is_16x16) 16 else 8;
+        const display_height: u16 = if (is_magnified) sprite_height * 2 else sprite_height;
+
+        var sprite_drawn: [framebuffer_width]bool = [_]bool{false} ** framebuffer_width;
+        var sprites_on_line: usize = 0;
+
+        var sprite_idx: usize = 0;
+        while (sprite_idx < 32) : (sprite_idx += 1) {
+            // TMS9918 SAT: 4 bytes per sprite (Y, X, pattern, color/EC)
+            const sat_entry = sat_base + @as(u16, @intCast(sprite_idx)) * 4;
+            const y_raw = self.vram[sat_entry & 0x3FFF];
+            if (y_raw == 0xD0) break;
+            const sprite_y: i16 = @as(i16, y_raw) + 1;
+            if (sprite_y > @as(i16, @intCast(line)) or sprite_y + @as(i16, @intCast(display_height)) <= @as(i16, @intCast(line)))
+                continue;
+
+            sprites_on_line += 1;
+            if (sprites_on_line > 4) {
+                self.status |= status_sprite_overflow;
+                break;
+            }
+
+            const sprite_x_raw = self.vram[(sat_entry + 1) & 0x3FFF];
+            const pattern = self.vram[(sat_entry + 2) & 0x3FFF];
+            const attr = self.vram[(sat_entry + 3) & 0x3FFF];
+            const color_idx: u4 = @truncate(attr & 0x0F);
+            const early_clock = (attr & 0x80) != 0;
+            const sprite_x: i16 = @as(i16, sprite_x_raw) - if (early_clock) @as(i16, 32) else 0;
+
+            if (color_idx == 0) continue;
+            const color = tmsPaletteColor(color_idx);
+
+            const row_in_sprite: u16 = if (is_magnified)
+                (@as(u16, @intCast(line)) -| @as(u16, @intCast(@max(sprite_y, 0)))) / 2
+            else
+                @as(u16, @intCast(line)) -| @as(u16, @intCast(@max(sprite_y, 0)));
+
+            const effective_pattern: u16 = if (is_16x16) @as(u16, pattern) & 0xFC else pattern;
+            const cols: usize = if (is_16x16) 2 else 1;
+
+            for (0..cols) |col| {
+                const pg_offset: u16 = if (is_16x16)
+                    effective_pattern * 8 + @as(u16, @intCast(col)) * 16 + row_in_sprite
+                else
+                    effective_pattern * 8 + row_in_sprite;
+                const pg_addr = sg_base + pg_offset;
+                const pattern_byte = self.vram[pg_addr & 0x3FFF];
+
+                for (0..8) |bit| {
+                    const mask = @as(u8, 0x80) >> @intCast(bit);
+                    if ((pattern_byte & mask) == 0) continue;
+
+                    const px_offset: i16 = @intCast(col * 8 + bit);
+                    const raw_px = sprite_x + if (is_magnified) px_offset * 2 else px_offset;
+
+                    const pixels_to_draw: usize = if (is_magnified) 2 else 1;
+                    for (0..pixels_to_draw) |sub| {
+                        const px = raw_px + @as(i16, @intCast(sub));
+                        if (px >= 0 and px < framebuffer_width) {
+                            const ux: usize = @intCast(px);
+                            if (sprite_drawn[ux]) {
+                                self.status |= status_sprite_collision;
+                            } else {
+                                line_buf[ux] = color;
+                                sprite_drawn[ux] = true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // -- Mode 4 rendering (SMS/GG) --
 
     fn renderBackground(self: *SmsVdp, line: u16, line_buf: *[framebuffer_width]u32, priority_buf: *[framebuffer_width]bool) void {
         const name_base = self.nameTableBase();
@@ -933,4 +1222,44 @@ test "gg vdp display height is always 144" {
     vdp.regs[1] = 0x98; // M1=1, M3=1
     // GG display height should still return 144
     try testing.expectEqual(@as(u16, 144), vdp.displayHeight());
+}
+
+test "displayMode returns mode4 when M4 bit is set" {
+    var vdp = SmsVdp.init();
+    vdp.regs[0] = 0x04; // M4=1
+    try testing.expectEqual(SmsVdp.GraphicsMode.mode4, vdp.graphicsMode());
+}
+
+test "displayMode returns mode2_graphics2 when M2 bit is set" {
+    var vdp = SmsVdp.init();
+    vdp.regs[0] = 0x02; // M2=1, M4=0
+    vdp.regs[1] = 0x00;
+    try testing.expectEqual(SmsVdp.GraphicsMode.mode2_graphics2, vdp.graphicsMode());
+}
+
+test "displayMode returns mode0_text when M1 bit is set" {
+    var vdp = SmsVdp.init();
+    vdp.regs[0] = 0x00; // M4=0, M2=0
+    vdp.regs[1] = 0x10; // M1=1
+    try testing.expectEqual(SmsVdp.GraphicsMode.mode0_text, vdp.graphicsMode());
+}
+
+test "displayMode returns mode3_multicolor when M3 bit is set" {
+    var vdp = SmsVdp.init();
+    vdp.regs[0] = 0x00;
+    vdp.regs[1] = 0x08; // M3=1
+    try testing.expectEqual(SmsVdp.GraphicsMode.mode3_multicolor, vdp.graphicsMode());
+}
+
+test "displayMode returns mode1_graphics1 as default TMS mode" {
+    var vdp = SmsVdp.init();
+    vdp.regs[0] = 0x00;
+    vdp.regs[1] = 0x00;
+    try testing.expectEqual(SmsVdp.GraphicsMode.mode1_graphics1, vdp.graphicsMode());
+}
+
+test "tms palette has 16 entries with correct black and white" {
+    try testing.expectEqual(@as(u32, 0xFF000000), SmsVdp.tmsPaletteColor(1)); // black
+    try testing.expectEqual(@as(u32, 0xFFFFFFFF), SmsVdp.tmsPaletteColor(15)); // white
+    try testing.expect(SmsVdp.tms_palette[0] != SmsVdp.tms_palette[1]); // transparent != black
 }

--- a/src/system.zig
+++ b/src/system.zig
@@ -6,6 +6,7 @@ pub const SystemType = enum {
     genesis,
     sms,
     gg,
+    sg1000,
 };
 
 /// Detect whether a ROM belongs to a Genesis or SMS system.
@@ -24,6 +25,26 @@ pub fn detectSystem(rom: []const u8) SystemType {
     if (rom.len >= 0x104 and std.mem.eql(u8, rom[0x100..0x104], "SEGA")) return .genesis;
     // Default to Genesis for unknown ROMs
     return .genesis;
+}
+
+/// Detect system type from file extension alone. Returns null if the
+/// extension does not uniquely identify a system (e.g. ".bin" could be
+/// Genesis or SMS).
+pub fn detectSystemFromExtension(path: []const u8) ?SystemType {
+    const ext = std.fs.path.extension(path);
+    if (std.ascii.eqlIgnoreCase(ext, ".sg")) return .sg1000;
+    if (std.ascii.eqlIgnoreCase(ext, ".gg")) return .gg;
+    if (std.ascii.eqlIgnoreCase(ext, ".sms")) return .sms;
+    return null;
+}
+
+test "detect system from extension" {
+    try testing.expectEqual(SystemType.sg1000, detectSystemFromExtension("game.sg").?);
+    try testing.expectEqual(SystemType.sg1000, detectSystemFromExtension("path/to/game.SG").?);
+    try testing.expectEqual(SystemType.gg, detectSystemFromExtension("game.gg").?);
+    try testing.expectEqual(SystemType.sms, detectSystemFromExtension("game.sms").?);
+    try testing.expect(detectSystemFromExtension("game.bin") == null);
+    try testing.expect(detectSystemFromExtension("game.md") == null);
 }
 
 test "detect system genesis" {

--- a/src/system_machine.zig
+++ b/src/system_machine.zig
@@ -51,10 +51,14 @@ pub const SystemMachine = union(enum) {
             // Read the file (with ZIP extraction support) and detect system type.
             const rom_data = try rom_loader.readRomFile(allocator, path, 8 * 1024 * 1024);
             const effective_path = effectiveRomPath(path);
-            const sys = system_detect.detectSystem(rom_data);
-            if (sys == .sms or sys == .gg) {
+            // Extension-based detection takes priority (e.g. .sg for SG-1000).
+            // Use effective_path (.zip stripped) so ".sg.zip" resolves to ".sg".
+            const sys = system_detect.detectSystemFromExtension(effective_path) orelse
+                system_detect.detectSystem(rom_data);
+            if (sys == .sms or sys == .gg or sys == .sg1000) {
                 var sms = try SmsMachine.initFromRomBytes(allocator, rom_data);
                 sms.is_game_gear = (sys == .gg);
+                sms.is_sg1000 = (sys == .sg1000);
                 allocator.free(rom_data);
                 try sms.bus.setSourcePath(allocator, effective_path);
                 sms.bindPointers();
@@ -87,7 +91,7 @@ pub const SystemMachine = union(enum) {
     pub fn systemType(self: *const SystemMachine) SystemType {
         return switch (self.*) {
             .genesis => .genesis,
-            .sms => |*s| if (s.is_game_gear) .gg else .sms,
+            .sms => |*s| if (s.is_game_gear) .gg else if (s.is_sg1000) .sg1000 else .sms,
         };
     }
 

--- a/src/testing/api.zig
+++ b/src/testing/api.zig
@@ -1,3 +1,4 @@
+pub const SmsMachine = @import("../sms/machine.zig").SmsMachine;
 pub const PendingAudioFrames = @import("../audio/timing.zig").PendingAudioFrames;
 pub const AudioTiming = @import("audio_timing.zig").AudioTiming;
 pub const ControllerIo = @import("controller_io.zig").ControllerIo;

--- a/src/wasm.zig
+++ b/src/wasm.zig
@@ -98,9 +98,10 @@ fn initWasmEmulator(alloc: std.mem.Allocator, raw_bytes: []const u8) !WasmEmulat
                 .last_save_len = 0,
             };
         },
-        .sms, .gg => {
+        .sms, .gg, .sg1000 => {
             var sms = try SmsMachine.initFromRomBytes(alloc, rom_bytes);
             sms.is_game_gear = (sys == .gg);
+            sms.is_sg1000 = (sys == .sg1000);
             return .{
                 .system = .{ .sms = .{ .machine = sms } },
                 .audio_buffer = [_]i16{0} ** 8192,
@@ -438,7 +439,7 @@ export fn sandopolis_display_mode(emu: *const WasmEmulator) u32 {
 export fn sandopolis_system_type(emu: *const WasmEmulator) u32 {
     return switch (emu.system) {
         .genesis => 0,
-        .sms => |*s| if (s.machine.is_game_gear) @as(u32, 2) else 1,
+        .sms => |*s| if (s.machine.is_game_gear) @as(u32, 2) else if (s.machine.is_sg1000) @as(u32, 3) else 1,
     };
 }
 

--- a/tests/regression_tests.zig
+++ b/tests/regression_tests.zig
@@ -701,6 +701,80 @@ test "immediate cram write updates palette before fifo drains" {
     try testing.expectEqual(@as(u8, 0xEE), emulator.handle.machine.bus.vdp.cram[0x0003]);
 }
 
+test "bulk cram rewrite near vblank does not leave stale palette in next frame" {
+    // Scene transitions (e.g. Zabu) rewrite all 64 CRAM palette entries near
+    // the end of the active display. If the palette update straddles the VBlank
+    // boundary and the emulator's CRAM handling is incorrect, the next rendered
+    // frame could show corrupted (inverted/"photo negative") colors for one or
+    // more scanlines.
+    //
+    // This test writes a known palette during VBlank, runs a frame so the VDP
+    // renders with it, then overwrites the entire palette with new colors right
+    // before the next VBlank and checks that the frame AFTER uses only the new
+    // palette values (no stale entries from the old palette).
+    const rom = try seedResetNopsRom(testing.allocator, 1);
+    defer testing.allocator.free(rom);
+
+    var emulator = try Emulator.initFromRomBytes(testing.allocator, rom);
+    defer emulator.deinit(testing.allocator);
+    emulator.reset();
+
+    // Enable display (register 1, bit 6)
+    emulator.setVdpRegister(1, 0x44);
+    emulator.setVdpRegister(15, 2); // auto-increment = 2
+
+    // Run a few frames to stabilize
+    emulator.runFrames(5);
+
+    // Phase 1: Write "old" palette (all entries = blue 0x0E00)
+    emulator.configureVdpDataPort(0x03, 0x0000, 2); // CRAM write, addr 0, inc 2
+    for (0..64) |_| {
+        emulator.writeVdpData(0x0E00); // blue
+    }
+
+    // Run one frame so VDP renders with the blue palette
+    emulator.runFrame();
+
+    // Phase 2: Overwrite entire palette with red (0x000E) near the VBlank edge.
+    // We advance to the last few active scanlines, then do the bulk rewrite.
+    // Advance partway into the frame (up to ~scanline 200 out of 224 active).
+    const master_cycles_per_line = 3420;
+    emulator.runMasterSlice(200 * master_cycles_per_line);
+
+    // Now rewrite all 64 CRAM entries with red
+    emulator.configureVdpDataPort(0x03, 0x0000, 2);
+    for (0..64) |_| {
+        emulator.writeVdpData(0x000E); // red
+    }
+
+    // Finish this frame and render one more full frame
+    emulator.runFrame();
+    emulator.runFrame();
+
+    // Verify: all 64 CRAM entries should be red (0x000E)
+    const vdp = &emulator.handle.machine.bus.vdp;
+    for (0..64) |i| {
+        const hi = vdp.cram[i * 2];
+        const lo = vdp.cram[i * 2 + 1];
+        const color: u16 = (@as(u16, hi) << 8) | lo;
+        try testing.expectEqual(@as(u16, 0x000E), color);
+    }
+
+    // Also verify the rendered framebuffer does not contain blue pixels.
+    // Backdrop (palette 0, entry 0) should be red, so any blue pixel would
+    // indicate a stale palette reference.
+    const fb = emulator.framebuffer();
+    var blue_pixels: usize = 0;
+    for (fb) |pixel| {
+        // ARGB format: blue channel at bits 0-7
+        const r = (pixel >> 16) & 0xFF;
+        const b = pixel & 0xFF;
+        // Old blue palette: high B, low R. New red: high R, low B.
+        if (b > 0x80 and r < 0x20) blue_pixels += 1;
+    }
+    try testing.expectEqual(@as(usize, 0), blue_pixels);
+}
+
 test "z80 executes proportionally within a long scheduler slice" {
     // With finer-grained Z80 burst slicing, the Z80 should execute
     // partway through a long slice, not only at the end.  A Z80 NOP
@@ -1254,4 +1328,114 @@ test "golden axe boots and produces visible output" {
     }
     try testing.expect(non_black_pixels > 0);
     try testing.expect(countUniqueFramebufferColors(fb, 16) > 3);
+}
+
+// --- Zabu palette investigation (local ROM, skipped if ROM not present) ---
+
+const zabu_rom_path = "/tmp/zabu/Zabu_demo_2026-01-24.bin";
+
+fn cramSnapshot(vdp: anytype) [128]u8 {
+    var snap: [128]u8 = undefined;
+    for (0..128) |i| {
+        snap[i] = vdp.cram[i];
+    }
+    return snap;
+}
+
+fn cramDiffCount(a: [128]u8, b: [128]u8) usize {
+    var diff: usize = 0;
+    for (0..64) |i| {
+        if (a[i * 2] != b[i * 2] or a[i * 2 + 1] != b[i * 2 + 1]) diff += 1;
+    }
+    return diff;
+}
+
+test "zabu palette investigation: detect bulk cram rewrites during scene transitions" {
+    // This test runs the Zabu demo ROM for 600 frames, capturing CRAM state
+    // at each frame to identify scene transitions (bulk palette rewrites).
+    // For each transition frame, it verifies that the framebuffer does not
+    // contain pixels from a fully inverted ("photo negative") palette.
+    //
+    // Skipped if the ROM is not present (CI does not have local ROMs).
+    var emulator = Emulator.init(testing.allocator, zabu_rom_path) catch |err| {
+        if (err == error.FileNotFound) return; // skip on CI
+        return err;
+    };
+    defer emulator.deinit(testing.allocator);
+    emulator.reset();
+
+    var prev_cram: [128]u8 = cramSnapshot(&emulator.handle.machine.bus.vdp);
+    const total_frames: usize = 600;
+    var transition_count: usize = 0;
+    var frames_with_inverted_palette: usize = 0;
+
+    for (0..total_frames) |frame| {
+        emulator.runFrame();
+
+        const cur_cram = cramSnapshot(&emulator.handle.machine.bus.vdp);
+        const diff = cramDiffCount(prev_cram, cur_cram);
+
+        // Detect bulk palette rewrite (scene transition)
+        if (diff >= 8) {
+            transition_count += 1;
+
+            std.debug.print("Frame {d}: {d}/64 CRAM entries changed\n", .{ frame, diff });
+            std.debug.print("  Old palette 0: ", .{});
+            for (0..16) |i| std.debug.print("{X:0>2}{X:0>2} ", .{ prev_cram[i * 2], prev_cram[i * 2 + 1] });
+            std.debug.print("\n  New palette 0: ", .{});
+            for (0..16) |i| std.debug.print("{X:0>2}{X:0>2} ", .{ cur_cram[i * 2], cur_cram[i * 2 + 1] });
+            std.debug.print("\n", .{});
+
+            // Check rendered framebuffer for "inverted" colors.
+            // An inverted palette would swap RGB channels or produce
+            // complement colors. Detect this by checking if most non-black
+            // pixels have inverted-looking channel relationships compared
+            // to the expected new palette's dominant color.
+            const fb = emulator.framebuffer();
+            const new_bg_r: u8 = @truncate((@as(u16, cur_cram[1]) & 0x0E));
+            const new_bg_g: u8 = @truncate((@as(u16, cur_cram[1]) >> 4) & 0x0E);
+            const new_bg_b: u8 = @truncate((@as(u16, cur_cram[0]) & 0x0E));
+
+            // Count pixels whose channels look like a bitwise complement of the
+            // new backdrop color (inverted/"photo negative" appearance).
+            var complement_pixels: usize = 0;
+            var total_visible: usize = 0;
+            for (fb) |pixel| {
+                const r: u8 = @truncate((pixel >> 16) & 0xFF);
+                const g: u8 = @truncate((pixel >> 8) & 0xFF);
+                const b: u8 = @truncate(pixel & 0xFF);
+                if (r == 0 and g == 0 and b == 0) continue;
+                total_visible += 1;
+
+                // Genesis CRAM is 9-bit (3 bits per channel, shifted left by 1).
+                // An "inverted" palette would have channels that are the bitwise
+                // complement of expected values.  Check if the rendered pixel's
+                // dominant channel is opposite to the new backdrop's dominant channel.
+                const inv_r: u8 = ~new_bg_r;
+                const inv_g: u8 = ~new_bg_g;
+                const inv_b: u8 = ~new_bg_b;
+                const dist_inv = @as(u16, if (r > inv_r) r - inv_r else inv_r - r) +
+                    @as(u16, if (g > inv_g) g - inv_g else inv_g - g) +
+                    @as(u16, if (b > inv_b) b - inv_b else inv_b - b);
+                if (dist_inv < 30) complement_pixels += 1;
+            }
+
+            if (total_visible > 0 and complement_pixels > total_visible / 2) {
+                frames_with_inverted_palette += 1;
+                std.debug.print("  ** INVERTED PALETTE DETECTED at frame {d} **\n", .{frame});
+            }
+            std.debug.print("\n", .{});
+        }
+
+        prev_cram = cur_cram;
+    }
+
+    std.debug.print("=== Zabu investigation: {d} transitions in {d} frames, {d} inverted frames ===\n", .{
+        transition_count, total_frames, frames_with_inverted_palette,
+    });
+
+    // The test passes as long as no fully inverted frames are detected.
+    // Brief single-frame palette flicker (< 50% inverted pixels) is authentic
+    // hardware behavior during scene transitions.
+    try testing.expectEqual(@as(usize, 0), frames_with_inverted_palette);
 }

--- a/tests/regression_tests.zig
+++ b/tests/regression_tests.zig
@@ -1439,3 +1439,58 @@ test "zabu palette investigation: detect bulk cram rewrites during scene transit
     // hardware behavior during scene transitions.
     try testing.expectEqual(@as(usize, 0), frames_with_inverted_palette);
 }
+
+// --- SG-1000 boot tests (local ROMs, skipped if not present) ---
+
+const SmsMachine = sandopolis.testing.SmsMachine;
+
+fn initSg1000(rom_path: []const u8) !SmsMachine {
+    const rom_data = std.fs.cwd().readFileAlloc(testing.allocator, rom_path, 1024 * 1024) catch |err| {
+        return err;
+    };
+    var machine = try SmsMachine.initFromRomBytes(testing.allocator, rom_data);
+    testing.allocator.free(rom_data);
+    machine.is_sg1000 = true;
+    // Do NOT call bindPointers() here: the struct will be returned by value
+    // and moved to the caller's stack. runFrame() calls bindPointers() lazily
+    // once the struct is at its final address.
+    return machine;
+}
+
+test "sg1000 dragon wang boots and produces visible output" {
+    var machine = initSg1000("roms/Dragon Wang (Japan) (Alt).sg") catch |err| {
+        if (err == error.FileNotFound) return;
+        return err;
+    };
+    defer machine.deinit(testing.allocator);
+
+    for (0..300) |_| machine.runFrame();
+
+    const fb = machine.framebuffer();
+    var non_black_pixels: usize = 0;
+    for (fb) |pixel| {
+        if (pixel != 0xFF000000 and pixel != 0x00000000) non_black_pixels += 1;
+    }
+
+    try testing.expect(non_black_pixels > 100);
+    try testing.expect(countUniqueFramebufferColors(fb, 8) > 1);
+}
+
+test "sg1000 hustle chumy boots and produces visible output" {
+    var machine = initSg1000("roms/Hustle Chumy (Japan).sg") catch |err| {
+        if (err == error.FileNotFound) return;
+        return err;
+    };
+    defer machine.deinit(testing.allocator);
+
+    // Hustle Chumy has a longer title screen; give it more frames
+    for (0..180) |_| machine.runFrame();
+
+    const fb = machine.framebuffer();
+    var non_black_pixels: usize = 0;
+    for (fb) |pixel| {
+        if (pixel != 0xFF000000 and pixel != 0x00000000) non_black_pixels += 1;
+    }
+    // Some SG-1000 games may render fewer visible pixels on title screens
+    try testing.expect(non_black_pixels > 10);
+}

--- a/web/index.html
+++ b/web/index.html
@@ -259,7 +259,7 @@
         }
 
         #screen.aspect-native {
-            aspect-ratio: 320 / 224;
+            /* Set dynamically via JS based on emulated system resolution */
         }
 
         #screen.integer-scale {
@@ -301,7 +301,7 @@
         }
 
         #screen-container.fullscreen #screen.aspect-native {
-            aspect-ratio: 320/224;
+            /* Set dynamically via JS based on emulated system resolution */
         }
 
         /* CRT bezel overlay */
@@ -1161,7 +1161,7 @@
         <select id="aspect-mode" title="Display aspect ratio mode">
             <option value="fit" title="Correct 4:3 TV aspect ratio">4:3 Fit</option>
             <option value="stretch" title="Stretch to fill the screen area">Stretch</option>
-            <option value="native" title="Raw pixel dimensions without correction">Native (320x224)</option>
+            <option value="native" title="Raw pixel dimensions without correction">Native</option>
         </select>
         <label>Scaling</label>
         <select id="scale-mode" title="Pixel scaling mode">

--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta content="width=device-width, initial-scale=1" name="viewport">
-    <title>Sandopolis - Sega Genesis / Master System / Game Gear Emulator</title>
+    <title>Sandopolis - Sega Genesis / Master System / Game Gear / SG-1000 Emulator</title>
     <style>
         * {
             margin: 0;
@@ -1093,14 +1093,14 @@
 
 <header>
     <h1>SANDOPOLIS</h1>
-    <span class="subtitle">Sega Genesis / Master System / Game Gear Emulator</span>
+    <span class="subtitle">Sega Genesis / Master System / Game Gear / SG-1000 Emulator</span>
     <br>
     <span class="era-tag">8-BIT</span> <span class="era-tag">16-BIT</span>
 </header>
 
 <div id="drop-zone">
     <label for="rom-input">Drop a ROM file here or <u>click to browse</u></label>
-    <input accept=".bin,.md,.smd,.gen,.sms,.gg,.zip" id="rom-input" type="file">
+    <input accept=".bin,.md,.smd,.gen,.sms,.gg,.sg,.zip" id="rom-input" type="file">
     <select id="recent-roms" style="display:none">
         <option value="">Recent ROMs...</option>
     </select>

--- a/web/sandopolis.js
+++ b/web/sandopolis.js
@@ -374,9 +374,18 @@ function applyAspectMode() {
     if (scaleMode === "integer") {
         c.classList.add("integer-scale");
         sc.classList.add("integer-container");
+        c.style.aspectRatio = "";
         applyIntegerScale();
     } else {
         c.classList.add("aspect-" + aspectMode);
+        // Native mode: set aspect ratio from actual canvas dimensions
+        if (aspectMode === "native") {
+            const w = c.width || 320;
+            const h = c.height || 224;
+            c.style.aspectRatio = w + " / " + h;
+        } else {
+            c.style.aspectRatio = "";
+        }
     }
 }
 
@@ -995,7 +1004,8 @@ function frameLoop(now) {
         canvas.width = width;
         canvas.height = height;
         imageData = ctx.createImageData(width, height);
-        if (scaleMode === "integer") applyIntegerScale();
+        // Reapply aspect/scale mode for the new resolution
+        applyAspectMode();
     }
     if (!imageData) imageData = ctx.createImageData(width, height);
 


### PR DESCRIPTION
## Summary

This Pull Request adds SG-1000 support to the Sandopolis emulator, updating documentation, UI, ROM handling, and emulation subsystems. It also introduces several rendering improvements for SG-1000 compatibility, new tests, and related configurations.

## Main Changes

* **Documentation Updates:** Added SG-1000 references to README.md, AGENTS.md, and ROADMAP.md.
* **ROM Handling Enhancements:** Extended .sg extension compatibility and SG-1000 detection in subsystem logic.

* **Emulation Updates**
  * Updated VDP, SMS bus, and system machine to support SG-1000-specific behavior (e.g., memory mapping and TMS9918A video rendering).
  * Added TMS9918A-exclusive graphics modes and palette handling.
* **HTML/JS UI Adjustments:** Modified the web emulator interface to include SG-1000 support, dynamic aspect ratio setting for native resolutions, and expanded ROM input compatibility.
* **Tests**: Added regression and SG-1000-specific emulation tests to validate new features.