### PR TITLE
Deploy Sandopolis Web via GitHub Actions

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -13,16 +13,21 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
 
 jobs:
-  deploy-web:
+  build-web:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           lfs: true
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
 
       - name: Install Zig
         uses: goto-bus-stop/setup-zig@v2
@@ -51,12 +56,18 @@ jobs:
           # This guard fails the deploy if it ever goes missing.
           test -f ./publish/CREDITS.txt
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./publish
-          publish_branch: gh-pages
-          user_name: ${{ github.actor }}
-          user_email: ${{ github.actor }}@users.noreply.github.com
-          commit_message: "web: Deploy Sandopolis Web from ${{ github.sha }}"
+          path: ./publish
+
+  deploy-web:
+    runs-on: ubuntu-latest
+    needs: build-web
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .sandopolis,
-    .version = "0.1.0-alpha.7",
+    .version = "0.1.0-alpha.8",
     .fingerprint = 0x50bf614ce7c127dd, // Changing this has security and trust implications.
     .minimum_zig_version = "0.15.2",
     .dependencies = .{


### PR DESCRIPTION
* Switched to deploying Sandopolis Web via GitHub Actions.