### PR TITLE
Pin CI Zig version detection to bash shell

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,14 +10,15 @@ indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.{c,h,zig,js}]
+[*.{c,h,zig,js,py}]
 max_line_length = 100
 
 [*.md]
 max_line_length = 150
 trim_trailing_whitespace = false
 
-[*.sh]
+[*.{txt}]
+max_line_length = 100
 indent_size = 2
 
 [*.{yml,yaml,json}]

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,7 @@ indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.{c,h,zig}]
+[*.{c,h,zig,js}]
 max_line_length = 100
 
 [*.md]
@@ -22,3 +22,6 @@ indent_size = 2
 
 [*.{yml,yaml,json}]
 indent_size = 2
+
+[*.{html,css}]
+max_line_length = 130

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,9 +103,8 @@ jobs:
 
       - name: Determine Zig version
         id: zigver
-        # shell must be bash: the Windows runner defaults to pwsh, where
-        # $GITHUB_OUTPUT does not expand and the empty version silently
-        # installs zig master.
+        # shell must be Bash: the Windows runner defaults to PowerShell, where
+        # $GITHUB_OUTPUT does not expand and the empty version silently installs zig master.
         shell: bash
         run: |
           version="$(sed -n 's/.*\.minimum_zig_version = "\(.*\)".*/\1/p' build.zig.zon)"
@@ -307,8 +306,7 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository_owner }}/sandopolis-web
           # `latest` is reserved for actual tag pushes; manual workflow_dispatch
-          # runs publish under `develop` instead so they cannot overwrite a
-          # released image.
+          # runs publish under `develop` instead so they cannot overwrite a released image.
           tags: |
             type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
             type=raw,value=develop,enable=${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,17 @@ jobs:
 
       - name: Determine Zig version
         id: zigver
-        run: echo "version=$(sed -n 's/.*\.minimum_zig_version = "\(.*\)".*/\1/p' build.zig.zon)" >> "$GITHUB_OUTPUT"
+        # shell must be bash: the Windows runner defaults to pwsh, where
+        # $GITHUB_OUTPUT does not expand and the empty version silently
+        # installs zig master.
+        shell: bash
+        run: |
+          version="$(sed -n 's/.*\.minimum_zig_version = "\(.*\)".*/\1/p' build.zig.zon)"
+          if [ -z "$version" ]; then
+            echo "Failed to read minimum_zig_version from build.zig.zon" >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Install Zig
         uses: goto-bus-stop/setup-zig@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,14 @@ jobs:
 
       - name: Determine Zig version
         id: zigver
-        run: echo "version=$(sed -n 's/.*\.minimum_zig_version = "\(.*\)".*/\1/p' build.zig.zon)" >> "$GITHUB_OUTPUT"
+        shell: bash
+        run: |
+          version="$(sed -n 's/.*\.minimum_zig_version = "\(.*\)".*/\1/p' build.zig.zon)"
+          if [ -z "$version" ]; then
+            echo "Failed to read minimum_zig_version from build.zig.zon" >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Install Zig
         uses: goto-bus-stop/setup-zig@v2

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -32,7 +32,14 @@ jobs:
 
       - name: Determine Zig version
         id: zigver
-        run: echo "version=$(sed -n 's/.*\.minimum_zig_version = "\(.*\)".*/\1/p' build.zig.zon)" >> "$GITHUB_OUTPUT"
+        shell: bash
+        run: |
+          version="$(sed -n 's/.*\.minimum_zig_version = "\(.*\)".*/\1/p' build.zig.zon)"
+          if [ -z "$version" ]; then
+            echo "Failed to read minimum_zig_version from build.zig.zon" >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Install Zig
         uses: goto-bus-stop/setup-zig@v2


### PR DESCRIPTION
## Problem

The **Create Release** workflow's Windows legs failed (run for `v0.1.0-alpha.8`, #28) with `no field named 'build_root' in struct 'Build'` errors coming from **zig master** (`C:\hostedtoolcache\windows\zig\master\...`), even though the project pins Zig 0.16.0.

## Root cause

The `Determine Zig version` step has no explicit `shell:`. On `windows-latest` the default shell is **pwsh**, where the bash-ism `$GITHUB_OUTPUT` doesn't expand, so the step emitted an empty version and `setup-zig` silently fell back to its default: **master**. Zig master (0.17-dev) changed the `std.Build` API (`build_root`, `args`, `pathFromRoot`, `StepOptions.id`), which breaks every `build.zig` in the tree. Linux/macOS legs passed because their default shell is bash.

## Fix

- Force `shell: bash` on the version-detection step in `release.yml`, `tests.yml`, and `web.yml` (bash is available on all GitHub-hosted runners).
- Fail fast if `minimum_zig_version` can't be read from `build.zig.zon`, so an empty version can never silently install master again.

After merging, re-running the release workflow should produce the Windows artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)